### PR TITLE
fix: unregister a user

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -29,9 +29,13 @@ func (r *Registry) Register(id int32, v interface{}) {
 }
 
 // unregister a user
-func (r *Registry) Unregister(id int32) {
+func (r *Registry) Unregister(id int32, v interface{}) {
 	r.Lock()
-	delete(r.records, id)
+	if oldv, ok := r.records[id]; ok {
+		if oldv == v {
+			delete(r.records, id)
+		}
+	}
 	r.Unlock()
 }
 
@@ -55,8 +59,8 @@ func Register(id int32, v interface{}) {
 	_default_registry.Register(id, v)
 }
 
-func Unregister(id int32) {
-	_default_registry.Unregister(id)
+func Unregister(id int32, v interface{}) {
+	_default_registry.Unregister(id, v)
 }
 
 func Query(id int32) interface{} {

--- a/service.go
+++ b/service.go
@@ -63,7 +63,7 @@ func (s *server) Stream(stream GameService_StreamServer) error {
 	ch_ipc := make(chan *Game_Frame, DEFAULT_CH_IPC_SIZE)
 
 	defer func() {
-		registry.Unregister(sess.UserId)
+		registry.Unregister(sess.UserId, ch_ipc)
 		close(sess_die)
 		log.Debug("stream end:", sess.UserId)
 	}()


### PR DESCRIPTION
修复了客户端在切换网络后 ipc 有可能丢失的问题。

如以下场景：客户端 C 在 12:35:01 时登录建立sess1，然后 C 在 35 分 15 秒时因切换网络后重新登陆建立了 sess2 并注册新 ipc，但是 sess1 的 stream end 在 35 分 20 秒的时候才检测到，然后把 ipc unregisterer了。